### PR TITLE
Fix Readme - Broken installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read the [coding guidelines](CODING.md) and [style guide](CODINGSTYLE.md)
 
 ## Installing
 
-[Install instructions](https://docs.ethswarm.org/docs/installation/quick-start)
+[Install instructions](https://docs.ethswarm.org/docs/bee/installation/quick-start)
 
 ## Get in touch
 


### PR DESCRIPTION

### Description
The installation link in the readme is broken and has been updated to https://docs.ethswarm.org/docs/bee/installation/quick-start
